### PR TITLE
Set target fileExtensions for LineLength check

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-only-formatting.xml
+++ b/src/main/resources/checkstyle/checkstyle-only-formatting.xml
@@ -48,6 +48,7 @@
   <module name="FileLength" />
 
   <module name="LineLength">
+    <property name="fileExtensions" value="java, json, xml, groovy"/>
     <property name="max" value="120"/>
     <property name="ignorePattern" value="^import"/>
   </module>

--- a/src/main/resources/checkstyle/checkstyle-with-metrics.xml
+++ b/src/main/resources/checkstyle/checkstyle-with-metrics.xml
@@ -48,6 +48,7 @@
   <module name="FileLength" />
 
   <module name="LineLength">
+    <property name="fileExtensions" value="java, json, xml, groovy"/>
     <property name="max" value="120" />
     <property name="ignorePattern" value="^import" />
   </module>


### PR DESCRIPTION
Set target fileExtensions to "java, json, xml, groovy" for LineLength check