### PR TITLE
Ignore overridden methods in ParameterNumber

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-only-formatting.xml
+++ b/src/main/resources/checkstyle/checkstyle-only-formatting.xml
@@ -134,7 +134,9 @@
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="MethodLength" />
-    <module name="ParameterNumber" />
+    <module name="ParameterNumber">
+      <property name="ignoreOverriddenMethods" value="true" />
+    </module>
 
 
     <!-- Checks for whitespace                               -->

--- a/src/main/resources/checkstyle/checkstyle-with-metrics-extra-linelength.xml
+++ b/src/main/resources/checkstyle/checkstyle-with-metrics-extra-linelength.xml
@@ -133,7 +133,9 @@
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="MethodLength" />
-    <module name="ParameterNumber" />
+    <module name="ParameterNumber">
+      <property name="ignoreOverriddenMethods" value="true" />
+    </module>
 
 
     <!-- Checks for whitespace                               -->

--- a/src/main/resources/checkstyle/checkstyle-with-metrics.xml
+++ b/src/main/resources/checkstyle/checkstyle-with-metrics.xml
@@ -133,7 +133,9 @@
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="MethodLength" />
-    <module name="ParameterNumber" />
+    <module name="ParameterNumber">
+      <property name="ignoreOverriddenMethods" value="true" />
+    </module>
 
 
     <!-- Checks for whitespace                               -->


### PR DESCRIPTION
There's little users can do about it anyway.

Fixes #10