### PR TITLE
Allow public final fields

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-with-metrics-extra-linelength.xml
+++ b/src/main/resources/checkstyle/checkstyle-with-metrics-extra-linelength.xml
@@ -197,6 +197,7 @@
     <module name="InterfaceIsType" />
     <module name="VisibilityModifier">
       <property name="protectedAllowed" value="true" />
+      <property name="allowPublicFinalFields" value="true" />
     </module>
 
 

--- a/src/main/resources/checkstyle/checkstyle-with-metrics.xml
+++ b/src/main/resources/checkstyle/checkstyle-with-metrics.xml
@@ -197,6 +197,7 @@
     <module name="InterfaceIsType" />
     <module name="VisibilityModifier">
       <property name="protectedAllowed" value="true" />
+      <property name="allowPublicFinalFields" value="true" />
     </module>
 
 


### PR DESCRIPTION
"public final"-felter er standard best-practice for value-objects i Java, og å minimere mutabel tilstand er generelt en god praksis også ellers. Mage nyere prosjekter i etaten har utstrakt bruk av dem, og anser det som en styrke.
Å velge final der man kan bør belønnes (i form av mindre tasting og klarere kode) snarere enn å legges bak en terskel (å selv måtte endre regelsettet for å slippe getter-støy i koden).
Et lite nudge i retning av mer funksjonell design og mer bevisste valg rundt mutabilitet.